### PR TITLE
Fixing Image Type

### DIFF
--- a/src/image.cr
+++ b/src/image.cr
@@ -12,6 +12,7 @@ module IMG
     CUR
     GIF
     ICO
+    JPG
     LBM
     PCX
     PNG

--- a/src/image.cr
+++ b/src/image.cr
@@ -8,7 +8,7 @@ module IMG
   alias Init = LibIMG::Init
 
   enum Type
-    BPM
+    BMP
     CUR
     GIF
     ICO


### PR DESCRIPTION
Fixed typo in `BMP`, and added missing `JPG` according to https://www.libsdl.org/projects/SDL_image/docs/SDL_image.html#SEC10