### PR TITLE
Ignore a few things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /doc
-.DS_Store
 /samples/data

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /doc
+.DS_Store
+/samples/data

--- a/src/image.cr
+++ b/src/image.cr
@@ -12,6 +12,7 @@ module IMG
     CUR
     GIF
     ICO
+    JPG
     LBM
     PCX
     PNG

--- a/src/image.cr
+++ b/src/image.cr
@@ -8,7 +8,7 @@ module IMG
   alias Init = LibIMG::Init
 
   enum Type
-    BPM
+    BMP
     CUR
     GIF
     ICO


### PR DESCRIPTION
This commit ignores Mac's `.DS_Store` file as well the `samples/data` folder which contains all the sample images. This will help to keep the images locally for testing samples but without accidentally adding them in to the repo