### PR TITLE
Resolve duplicate SDL::Event::TouchFinger#touch_id

### DIFF
--- a/src/events.cr
+++ b/src/events.cr
@@ -157,7 +157,7 @@ module SDL
         @event.touchId
       end
 
-      def touch_id
+      def finger_id
         @event.fingerId
       end
     end
@@ -269,7 +269,7 @@ module SDL
     # queue is empty.
     def self.poll
       case LibSDL.poll_event(out event)
-      when 1 then
+      when 1
         from(event)
       when -1
         raise Error.new("SDL_PollEvent")


### PR DESCRIPTION
I noticed that the call to `fingerID` was incorrect, so I fixed it.

I also removed a `then` as `crystal tool format` was removing it. I didn't remove the empty lines between `when` clauses as I believe you are using them for grouping.

Let me know if this isn't the way you would like me to issue the pull request as there are no contribution guidelines in your README.