### PR TITLE
Fix: draw_lines(x1, y1, x2, y2) had a typo

### DIFF
--- a/src/renderer.cr
+++ b/src/renderer.cr
@@ -161,7 +161,7 @@ module SDL
 
     # Draw a single line between two `Point`.
     def draw_line(x1, y1, x2, y2)
-      ret = LibSDL.render_draw_line(self, x1, y2, x2, y2)
+      ret = LibSDL.render_draw_line(self, x1, y1, x2, y2)
       raise Error.new("SDL_RenderDrawLine") unless ret == 0
     end
 


### PR DESCRIPTION
The Y-value from the second point was used for both points.