### PR TITLE
fixed method call in basic sample. fixes #14

### DIFF
--- a/samples/basic.cr
+++ b/samples/basic.cr
@@ -17,6 +17,6 @@ loop do
     end
   end
 
-  window.surface.fill(255, 255, 255)
+  window.surface.fill(SDL::Rect[0, 0, 0, 0], 255, 255, 255)
   window.update
 end


### PR DESCRIPTION
This fixes the missing overload error:

```
Overloads are:
 - SDL::Surface#fill(rect, r, g, b, a = nil)

  window.surface.fill(255, 255, 255)
```