### PR TITLE
Fix SDL::Window#fullscreen

### DIFF
--- a/src/window.cr
+++ b/src/window.cr
@@ -83,7 +83,7 @@ module SDL
     end
 
     def fullscreen=(value : Bool)
-      self.fullscreen = value ? LibSDL::WindowFlags::FULLSCREEN_DESKTOP : LibSDL::WindowFlags::WINDOW
+      self.fullscreen = value ? Fullscreen::FULLSCREEN_DESKTOP : Fullscreen::WINDOW
     end
 
     def grab=(value)


### PR DESCRIPTION
Right now it gives you this when you use it:
```Crystal
Error in wool.cr:46: instantiating 'Wool::Window:Module#fullscreen(Bool)'

  Wool::Window.fullscreen true
               ^~~~~~~~~~

in window.cr:29: instantiating 'SDL::Window#fullscreen=(Bool)'

   window.fullscreen = true
          ^~~~~~~~~~

in lib/sdl/src/window.cr:86: undefined constant LibSDL::WindowFlags::WINDOW

      self.fullscreen = value ? LibSDL::WindowFlags::FULLSCREEN : LibSDL::WindowFlags::WINDOW
                                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```