### PR TITLE
Added SDL_GetWindowWMInfo support, and additional window flags

### DIFF
--- a/src/lib_sdl/video.cr
+++ b/src/lib_sdl/video.cr
@@ -28,6 +28,11 @@ lib LibSDL
     FULLSCREEN_DESKTOP = 0x00001001 # WINDOW_FULLSCREEN | 0x00001000
     FOREIGN = 0x00000800
     ALLOW_HIGHDPI = 0x00002000
+    ALWAYS_ON_TOP = 0x00008000 # x11 only
+    SKIP_TASKBAR = 0x00010000 # x11 only
+    UTILITY = 0x00020000 # x11 only
+    TOOLTIP = 0x00040000 # x11 only
+    POPUP_MENU = 0x00080000 # x11 only
   end
 
   enum WindowPosition
@@ -95,6 +100,31 @@ lib LibSDL
     RESET_ISOLATION_FLAG    = 0x0008
   end
 
+  struct SDL_Version
+    major : UInt8
+    minor : UInt8
+    patch : UInt8
+  end
+
+  enum SDL_SYSType
+    SDL_SYSWM_UNKNOWN
+    SDL_SYSWM_WINDOWS
+    SDL_SYSWM_X11
+    SDL_SYSWM_DIRECTFB
+    SDL_SYSWM_COCOA
+  end
+
+  struct WM_x11
+    display : Void*
+    window : UInt64
+  end
+
+  struct SDL_WMInfo
+    version : SDL_Version
+    subsystem : SDL_SYSType
+    info : WM_x11 # TODO: Add support for other WM's
+  end
+
   fun get_num_video_drivers = SDL_GetNumVideoDrivers() : Int
   fun get_video_driver = SDL_GetVideoDriver(index : Int) : Char*
   fun video_init = SDL_VideoInit(driver_name : Char*) : Int
@@ -118,6 +148,7 @@ lib LibSDL
   fun get_window_id = SDL_GetWindowID(window : Window*) : UInt32
   fun get_window_from_id = SDL_GetWindowFromID(id : UInt32) : Window*
   fun get_window_flags = SDL_GetWindowFlags(window : Window*) : WindowFlags
+  fun get_window_wm_info = SDL_GetWindowWMInfo(window : Window*, info : SDL_WMInfo*) : Bool
   fun set_window_title = SDL_SetWindowTitle(window : Window*, title : Char*)
   fun get_window_title = SDL_GetWindowTitle(window : Window*) : Char*
   fun set_window_icon = SDL_SetWindowIcon(window : Window*, icon : Surface*)

--- a/src/lib_sdl/video.cr
+++ b/src/lib_sdl/video.cr
@@ -112,17 +112,28 @@ lib LibSDL
     SDL_SYSWM_X11
     SDL_SYSWM_DIRECTFB
     SDL_SYSWM_COCOA
+    SDL_SYSWM_UIKIT
+    SDL_SYSWM_WAYLAND
+    SDL_SYSWM_MIR
+    SDL_SYSWM_WINRT
+    SDL_SYSWM_ANDROID
+    SDL_SYSWM_VIVANTE
+    SDL_SYSWM_OS2
   end
 
-  struct WM_x11
+  struct SDL_WMInfoX11
     display : Void*
-    window : UInt64
+    window : UInt32
+  end
+
+  union SDL_WMInfoUnion
+    x11 : SDL_WMInfoX11
   end
 
   struct SDL_WMInfo
     version : SDL_Version
     subsystem : SDL_SYSType
-    info : WM_x11 # TODO: Add support for other WM's
+    info : SDL_WMInfoUnion
   end
 
   fun get_num_video_drivers = SDL_GetNumVideoDrivers() : Int


### PR DESCRIPTION
SDL_GetWindowWMInfo can be used like so: 

        window = SDL::Window.new("Window", 640, 480)
        renderer = SDL::Renderer.new(window)

        win_info = LibSDL::SDL_WMInfo.new
        win_info.version.major = 2
        win_info.version.minor = 0
        win_info.version.patch = 1

        if LibSDL.get_window_wm_info window, pointerof(win_info)
          puts "SUCCESS!"
        else
          puts "FAILED?"
        end
        puts win_info

I also added 5 additional x11 specific window flags.