### PR TITLE
Mark bitfield enum with `@[Flags]`

### DIFF
--- a/src/lib_sdl/keycode.cr
+++ b/src/lib_sdl/keycode.cr
@@ -258,6 +258,7 @@ lib LibSDL
     SLEEP = Scancode::SLEEP | SDLK_SCANCODE_MASK
   end
 
+  @[Flags]
   enum Keymod : UInt16
     NONE = 0x0000
     LSHIFT = 0x0001


### PR DESCRIPTION
Things like `SDL::Event.poll.mod.lctrl?` won't work when several modifiers are active otherwise.
(Checking for `SDL::Event::Keyboard` is implied and omitted.)