### PR TITLE
Support Crystal 1.0.0 onwards, perhaps?

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -9,7 +9,7 @@ description: |
 
 license: MIT
 
-crystal: ">= 0.36, < 2.0"
+crystal: ">= 0.36, < 2.0.0"
 
 libraries:
   libSDL2: ~> 2.0.2

--- a/shard.yml
+++ b/shard.yml
@@ -9,7 +9,7 @@ description: |
 
 license: MIT
 
-crystal: >= 0.36, < 2
+crystal: ">= 0.36, < 2"
 
 libraries:
   libSDL2: ~> 2.0.2

--- a/shard.yml
+++ b/shard.yml
@@ -9,6 +9,8 @@ description: |
 
 license: MIT
 
+crystal: >= 0.36, < 2
+
 libraries:
   libSDL2: ~> 2.0.2
   libSDL2_image: ~> 2.0.0

--- a/shard.yml
+++ b/shard.yml
@@ -9,7 +9,7 @@ description: |
 
 license: MIT
 
-crystal: ">= 0.36, < 2.0.0"
+crystal: ">= 0.36.1, < 2.0.0"
 
 libraries:
   libSDL2: ~> 2.0.2

--- a/shard.yml
+++ b/shard.yml
@@ -9,7 +9,7 @@ description: |
 
 license: MIT
 
-crystal: ">= 0.36, < 2"
+crystal: ">= 0.36, < 2.0"
 
 libraries:
   libSDL2: ~> 2.0.2


### PR DESCRIPTION
While `crystal` [attribute](https://github.com/crystal-lang/shards/blob/master/docs/shard.yml.adoc#optional-attributes) is marked "optional", `shards` assumes it to be `< 1.0.0` when missing and fails to install with the following error:
```
Unable to satisfy the following requirements:

- `crystal (< 1.0.0)` required by `sdl 0.1.0+git.commit.b674fbaaf9ff8505b3e76cbd43528d2f0cfdbdc2`
Failed to resolve dependencies, try updating incompatible shards or use --ignore-crystal-version as a workaround if no update is available.
```
See if this version range seems legit for you.