### PR TITLE
Marked WindowsFlags as a flags bitfield.

### DIFF
--- a/src/lib_sdl/video.cr
+++ b/src/lib_sdl/video.cr
@@ -13,6 +13,7 @@ lib LibSDL
 
   type Window = Void
 
+  @[Flags]
   enum WindowFlags : UInt32
     FULLSCREEN = 0x00000001
     OPENGL = 0x00000002


### PR DESCRIPTION
For…
```cr
window = SDL::Window.new("SDL", 640, 480)
renderer = SDL::Renderer.new(window)
puts LibSDL.get_window_flags(window)
```
…turns…
```
# => 6
```
…into…
```
# => OPENGL | SHOWN
```