### PR TITLE
Fix bytes_per_pixel method

### DIFF
--- a/src/pixels.cr
+++ b/src/pixels.cr
@@ -14,12 +14,12 @@ module SDL
     end
 
     def bytes_per_pixel
-      @pixel_format.value.bitsPerPixel
+      @pixel_format.value.bytesPerPixel
     end
 
-    #def palette
+    # def palette
     #  Palette.new(@pixel_format.value.palette)
-    #end
+    # end
 
     def to_unsafe
       @pixel_format


### PR DESCRIPTION
PixelFormat is returning the same value as `bits_per_pixel` in the `bytes_per_pixel` method.