### PR TITLE
Allow streaming texture pixel access

### DIFF
--- a/src/lib_sdl/pixels.cr
+++ b/src/lib_sdl/pixels.cr
@@ -1,6 +1,6 @@
 lib LibSDL
-  ALPHA_OPAQUE = 255
-  ALPHA_TRANSPARENT = 0
+  ALPHA_OPAQUE      = 255
+  ALPHA_TRANSPARENT =   0
 
   enum PixelType
     UNKNOWN
@@ -57,55 +57,55 @@ lib LibSDL
     L1010102
   end
 
-  #macro DEFINE_PIXELFOURCC(A, B, C, D)
-  #  {{A}}.to_u32 << 0 |
-  #  {{B}}.to_u32 << 8 |
-  #  {{C}}.to_u32 << 16 |
-  #  {{D}}.to_u32 << 24
-  #end
+  # macro define_pixelfourcc(a, b, c, d)
+  #  {{a}}.ord.to_u32 << 0 |
+  #  {{b}}.ord.to_u32 << 8 |
+  #  {{c}}.ord.to_u32 << 16 |
+  #  {{d}}.ord.to_u32 << 24
+  # end
 
-  #macro DEFINE_PIXELFORMAT(type, order, layout, bits, bytes)
+  # macro define_pixelformat(type, order, layout, bits, bytes)
   #  ((1 << 28) | ({{type}} << 24) | ({{order}} << 20) | ({{layout}} << 16) | ({{bits}} << 8) | ({{bytes}} << 0))
-  #end
+  # end
 
-  #enum PixelFormatEnum : UInt32
-  #  UNKNOWN
-  #  INDEX1LSB = SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_INDEX1, SDL_BITMAPORDER_4321, 0, 1, 0)
-  #  INDEX1MSB = SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_INDEX1, SDL_BITMAPORDER_1234, 0, 1, 0)
-  #  INDEX4LSB = SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_INDEX4, SDL_BITMAPORDER_4321, 0, 4, 0)
-  #  INDEX4MSB = SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_INDEX4, SDL_BITMAPORDER_1234, 0, 4, 0)
-  #  INDEX8 = SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_INDEX8, 0, 0, 8, 1)
-  #  RGB332 = SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED8, SDL_PACKEDORDER_XRGB, SDL_PACKEDLAYOUT_332, 8, 1)
-  #  RGB444 = SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED16, SDL_PACKEDORDER_XRGB, SDL_PACKEDLAYOUT_4444, 12, 2)
-  #  RGB555 = SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED16, SDL_PACKEDORDER_XRGB, SDL_PACKEDLAYOUT_1555, 15, 2)
-  #  BGR555 = SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED16, SDL_PACKEDORDER_XBGR, SDL_PACKEDLAYOUT_1555, 15, 2)
-  #  ARGB4444 = SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED16, SDL_PACKEDORDER_ARGB, SDL_PACKEDLAYOUT_4444, 16, 2)
-  #  RGBA4444 = SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED16, SDL_PACKEDORDER_RGBA, SDL_PACKEDLAYOUT_4444, 16, 2)
-  #  ABGR4444 = SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED16, SDL_PACKEDORDER_ABGR, SDL_PACKEDLAYOUT_4444, 16, 2)
-  #  BGRA4444 = SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED16, SDL_PACKEDORDER_BGRA, SDL_PACKEDLAYOUT_4444, 16, 2)
-  #  ARGB1555 = SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED16, SDL_PACKEDORDER_ARGB, SDL_PACKEDLAYOUT_1555, 16, 2)
-  #  RGBA5551 = SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED16, SDL_PACKEDORDER_RGBA, SDL_PACKEDLAYOUT_5551, 16, 2)
-  #  ABGR1555 = SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED16, SDL_PACKEDORDER_ABGR, SDL_PACKEDLAYOUT_1555, 16, 2)
-  #  BGRA5551 = SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED16, SDL_PACKEDORDER_BGRA, SDL_PACKEDLAYOUT_5551, 16, 2)
-  #  RGB565 = SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED16, SDL_PACKEDORDER_XRGB, SDL_PACKEDLAYOUT_565, 16, 2)
-  #  BGR565 = SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED16, SDL_PACKEDORDER_XBGR, SDL_PACKEDLAYOUT_565, 16, 2)
-  #  RGB24 = SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_ARRAYU8, SDL_ARRAYORDER_RGB, 0, 24, 3)
-  #  BGR24 = SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_ARRAYU8, SDL_ARRAYORDER_BGR, 0, 24, 3)
-  #  RGB888 = SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED32, SDL_PACKEDORDER_XRGB, SDL_PACKEDLAYOUT_8888, 24, 4)
-  #  RGBX8888 = SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED32, SDL_PACKEDORDER_RGBX, SDL_PACKEDLAYOUT_8888, 24, 4)
-  #  BGR888 = SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED32, SDL_PACKEDORDER_XBGR, SDL_PACKEDLAYOUT_8888, 24, 4)
-  #  BGRX8888 = SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED32, SDL_PACKEDORDER_BGRX, SDL_PACKEDLAYOUT_8888, 24, 4)
-  #  ARGB8888 = SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED32, SDL_PACKEDORDER_ARGB, SDL_PACKEDLAYOUT_8888, 32, 4)
-  #  RGBA8888 = SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED32, SDL_PACKEDORDER_RGBA, SDL_PACKEDLAYOUT_8888, 32, 4)
-  #  ABGR8888 = SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED32, SDL_PACKEDORDER_ABGR, SDL_PACKEDLAYOUT_8888, 32, 4)
-  #  BGRA8888 = SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED32, SDL_PACKEDORDER_BGRA, SDL_PACKEDLAYOUT_8888, 32, 4)
-  #  ARGB2101010 = SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED32, SDL_PACKEDORDER_ARGB, SDL_PACKEDLAYOUT_2101010, 32, 4)
-  #  YV12 = SDL_DEFINE_PIXELFOURCC('Y', 'V', '1', '2')
-  #  IYUV = SDL_DEFINE_PIXELFOURCC('I', 'Y', 'U', 'V')
-  #  YUY2 = SDL_DEFINE_PIXELFOURCC('Y', 'U', 'Y', '2')
-  #  UYVY = SDL_DEFINE_PIXELFOURCC('U', 'Y', 'V', 'Y')
-  #  YVYU = SDL_DEFINE_PIXELFOURCC('Y', 'V', 'Y', 'U')
-  #end
+  enum PixelFormatEnum : UInt32
+    UNKNOWN
+    INDEX1LSB   = 1 << 28 | PixelType::INDEX1 << 24 | BitmapOrder::SDL_BITMAPORDER_4321 << 20 | 0 << 16 | 1 << 8 | 0
+    INDEX1MSB   = 1 << 28 | PixelType::INDEX1 << 24 | BitmapOrder::SDL_BITMAPORDER_1234 << 20 | 0 << 16 | 1 << 8 | 0
+    INDEX4LSB   = 1 << 28 | PixelType::INDEX4 << 24 | BitmapOrder::SDL_BITMAPORDER_4321 << 20 | 0 << 16 | 4 << 8 | 0
+    INDEX4MSB   = 1 << 28 | PixelType::INDEX4 << 24 | BitmapOrder::SDL_BITMAPORDER_1234 << 20 | 0 << 16 | 4 << 8 | 0
+    INDEX8      = 1 << 28 | PixelType::INDEX8 << 24 | 0 << 20 | 0 << 16 | 8 << 8 | 1
+    RGB332      = 1 << 28 | PixelType::PACKED8 << 24 | PackedOrder::XRGB << 20 | PackedLayout::L332 << 16 | 8 << 8 | 1
+    RGB444      = 1 << 28 | PixelType::PACKED16 << 24 | PackedOrder::XRGB << 20 | PackedLayout::L4444 << 16 | 12 << 8 | 2
+    RGB555      = 1 << 28 | PixelType::PACKED16 << 24 | PackedOrder::XRGB << 20 | PackedLayout::L1555 << 16 | 15 << 8 | 2
+    BGR555      = 1 << 28 | PixelType::PACKED16 << 24 | PackedOrder::XBGR << 20 | PackedLayout::L1555 << 16 | 15 << 8 | 2
+    ARGB4444    = 1 << 28 | PixelType::PACKED16 << 24 | PackedOrder::ARGB << 20 | PackedLayout::L4444 << 16 | 16 << 8 | 2
+    RGBA4444    = 1 << 28 | PixelType::PACKED16 << 24 | PackedOrder::RGBA << 20 | PackedLayout::L4444 << 16 | 16 << 8 | 2
+    ABGR4444    = 1 << 28 | PixelType::PACKED16 << 24 | PackedOrder::ABGR << 20 | PackedLayout::L4444 << 16 | 16 << 8 | 2
+    BGRA4444    = 1 << 28 | PixelType::PACKED16 << 24 | PackedOrder::BGRA << 20 | PackedLayout::L4444 << 16 | 16 << 8 | 2
+    ARGB1555    = 1 << 28 | PixelType::PACKED16 << 24 | PackedOrder::ARGB << 20 | PackedLayout::L1555 << 16 | 16 << 8 | 2
+    RGBA5551    = 1 << 28 | PixelType::PACKED16 << 24 | PackedOrder::RGBA << 20 | PackedLayout::L5551 << 16 | 16 << 8 | 2
+    ABGR1555    = 1 << 28 | PixelType::PACKED16 << 24 | PackedOrder::ABGR << 20 | PackedLayout::L1555 << 16 | 16 << 8 | 2
+    BGRA5551    = 1 << 28 | PixelType::PACKED16 << 24 | PackedOrder::BGRA << 20 | PackedLayout::L5551 << 16 | 16 << 8 | 2
+    RGB565      = 1 << 28 | PixelType::PACKED16 << 24 | PackedOrder::XRGB << 20 | PackedLayout::L565 << 16 | 16 << 8 | 2
+    BGR565      = 1 << 28 | PixelType::PACKED16 << 24 | PackedOrder::XBGR << 20 | PackedLayout::L565 << 16 | 16 << 8 | 2
+    RGB24       = 1 << 28 | PixelType::ARRAYU8 << 24 | ArrayOrder::RGB << 20 | 0 << 16 | 24 << 8 | 3
+    BGR24       = 1 << 28 | PixelType::ARRAYU8 << 24 | ArrayOrder::BGR << 20 | 0 << 16 | 24 << 8 | 3
+    RGB888      = 1 << 28 | PixelType::PACKED32 << 24 | PackedOrder::XRGB << 20 | PackedLayout::L8888 << 16 | 24 << 8 | 4
+    RGBX8888    = 1 << 28 | PixelType::PACKED32 << 24 | PackedOrder::RGBX << 20 | PackedLayout::L8888 << 16 | 24 << 8 | 4
+    BGR888      = 1 << 28 | PixelType::PACKED32 << 24 | PackedOrder::XBGR << 20 | PackedLayout::L8888 << 16 | 24 << 8 | 4
+    BGRX8888    = 1 << 28 | PixelType::PACKED32 << 24 | PackedOrder::BGRX << 20 | PackedLayout::L8888 << 16 | 24 << 8 | 4
+    ARGB8888    = 1 << 28 | PixelType::PACKED32 << 24 | PackedOrder::ARGB << 20 | PackedLayout::L8888 << 16 | 32 << 8 | 4
+    RGBA8888    = 1 << 28 | PixelType::PACKED32 << 24 | PackedOrder::RGBA << 20 | PackedLayout::L8888 << 16 | 32 << 8 | 4
+    ABGR8888    = 1 << 28 | PixelType::PACKED32 << 24 | PackedOrder::ABGR << 20 | PackedLayout::L8888 << 16 | 32 << 8 | 4
+    BGRA8888    = 1 << 28 | PixelType::PACKED32 << 24 | PackedOrder::BGRA << 20 | PackedLayout::L8888 << 16 | 32 << 8 | 4
+    ARGB2101010 = 1 << 28 | PixelType::PACKED32 << 24 | PackedOrder::ARGB << 20 | PackedLayout::L2101010 << 16 | 32 << 8 | 4
+    YV12        =  842094169
+    IYUV        = 1448433993
+    YUY2        =  844715353
+    UYVY        = 1498831189
+    YVYU        = 1431918169
+  end
 
   alias Color = SDL::Color
 
@@ -126,10 +126,10 @@ lib LibSDL
     g_mask : UInt32
     b_mask : UInt32
     a_mask : UInt32
-    r_loss  : UInt8
-    g_loss  : UInt8
-    b_loss  : UInt8
-    a_loss  : UInt8
+    r_loss : UInt8
+    g_loss : UInt8
+    b_loss : UInt8
+    a_loss : UInt8
     r_shift : UInt8
     g_shift : UInt8
     b_shift : UInt8


### PR DESCRIPTION
It appears that the macros which were ported from the SDL headers to define `PixelFormatEnum` don't work within the `enum` block (if anyone knows why, I'd love to learn about what is wrong there).

This PR replaces the macro call with the expanded values which are required to when using `LibSDL.create_texture`, and implements the `SDL::Texture#lock` method which yields a `Slice` pointing to the pixels buffer.