### PR TITLE
Add Rect.includes?()

### DIFF
--- a/src/rect.cr
+++ b/src/rect.cr
@@ -25,5 +25,13 @@ module SDL
 
     def initialize(@x, @y, @w, @h)
     end
+
+    def includes?(point : SDL::Point)
+      includes?(point.x, point.y)
+    end
+
+    def includes?(x : Int32, y : Int32)
+      @x <= x < @x + @w && @y <= y < @y + @h
+    end
   end
 end


### PR DESCRIPTION
SDL has `SDL_PointInRect()`, but we cannot call it since it is inlined.