### PR TITLE
Add game controller wrapper and sample

### DIFF
--- a/samples/19_gamepads_and_joysticks.cr
+++ b/samples/19_gamepads_and_joysticks.cr
@@ -1,0 +1,73 @@
+require "../src/sdl"
+require "../src/image"
+
+DEAD_ZONE = 8000
+
+SDL.init(SDL::Init::VIDEO | SDL::Init::JOYSTICK); at_exit { SDL.quit }
+SDL.set_hint(SDL::Hint::RENDER_SCALE_QUALITY, "1")
+
+SDL::IMG.init(SDL::IMG::Init::PNG); at_exit { SDL::IMG.quit }
+
+# are any joysticks connected?
+if LibSDL.num_joysticks < 1
+  puts "No joysticks connected!"
+end
+
+# get the first joystick
+unless game_controller = LibSDL.joystick_open(0)
+  puts "Could not open game controller. SDL Error: #{LibSDL.get_error}"
+end
+
+window = SDL::Window.new("SDL tutorial", 640, 480)
+renderer = SDL::Renderer.new(window)
+arrow = SDL::IMG.load(File.join(__DIR__, "data", "arrow.png"), renderer)
+
+x_dir = y_dir = 0
+
+loop do
+  case event = SDL::Event.poll
+  when SDL::Event::Quit
+    break
+  when SDL::Event::JoyAxis
+    # motion on controller 1
+    next unless event.which == 0
+
+    case event.axis
+    when 0                        # x-axis motion
+      if event.value < -DEAD_ZONE # left of dead zone
+        x_dir = -1
+      elsif event.value > DEAD_ZONE # right of dead zone
+        x_dir = 1
+      else # default value
+        x_dir = 0
+      end
+    when 1                        # y-axis motion
+      if event.value < -DEAD_ZONE # below dead zone
+        y_dir = -1
+      elsif event.value > DEAD_ZONE # above dead zone
+        y_dir = 1
+      else # default value
+        y_dir = 0
+      end
+    end
+  end
+
+  renderer.draw_color = SDL::Color[255]
+  renderer.clear
+
+  # calculate angle
+  joystick_angle = Math.atan2(y_dir.to_f, x_dir.to_f) * 180 / Math::PI
+
+  # correct angle
+  joystick_angle = 0 if x_dir == 0 && y_dir == 0
+
+  x = (window.width - arrow.width) // 2
+  y = (window.height - arrow.height) // 2
+  renderer.copy(arrow, dstrect: SDL::Rect[x, y, arrow.width, arrow.height], angle: joystick_angle)
+
+  renderer.present
+end
+
+# clean up data
+LibSDL.joystick_close(game_controller)
+[arrow, renderer, window].each(&.finalize)

--- a/samples/20_force_feedback.cr
+++ b/samples/20_force_feedback.cr
@@ -1,0 +1,85 @@
+require "../src/sdl"
+require "../src/image"
+
+SDL.init(SDL::Init::VIDEO | SDL::Init::HAPTIC | SDL::Init::GAMECONTROLLER); at_exit { SDL.quit }
+SDL.set_hint(SDL::Hint::RENDER_SCALE_QUALITY, "1")
+
+SDL::IMG.init(SDL::IMG::Init::PNG); at_exit { SDL::IMG.quit }
+
+window = SDL::Window.new("SDL tutorial", 640, 480)
+renderer = SDL::Renderer.new(window)
+texture = SDL::IMG.load(File.join(__DIR__, "data", "haptics.png"), renderer)
+
+# in this example, we are tracking the controllers by their instance ids and not the device's index id.
+# since the SDL controller events primarilly use the device's instance id and not its index.
+# see the loop below for more details.
+# get all connected controllers, if any.
+controllers : Hash(LibSDL::JoystickID, SDL::GameController) = (0..LibSDL.num_joysticks - 1).to_h do |idx|
+  {
+    SDL::GameController.instance_id(idx),
+    SDL::GameController.new(idx),
+  }
+end
+
+trigger_axis = {
+  left:  SDL::GameController::Axis::TRIGGERLEFT.value,
+  right: SDL::GameController::Axis::TRIGGERRIGHT.value,
+}
+
+loop do
+  case event = SDL::Event.poll
+  when SDL::Event::Quit
+    break
+  when SDL::Event::ControllerButton
+    # when a controller button is pressed, event.which returns the device instance id, NOT the device index
+    # make sure we have a valid controller
+    next unless controller = controllers[event.which]?
+
+    freq = (0xffff * 3 // 4).to_u16
+    controller.rumble(low_freq: freq, high_freq: freq, duration_ms: 500) # rumble at 75% strength for 500 milliseconds
+  when SDL::Event::ControllerDevice
+    if event.type.controller_device_added?
+      # when an SDL joystick / controller is added, event.which returns the device index, NOT the device instance id
+      # since we are tracking controllers by instance id, we need to get it's instance id
+      instance_id = SDL::GameController.instance_id(event.which)
+      controllers[instance_id] = SDL::GameController.new(event.which)
+
+      puts "Controller ##{instance_id} was connected"
+    elsif event.type.controller_device_removed?
+      # when a joystick / controller is removed, event.which returns the device instance id, NOT the device index
+      # event.which will also auto increment for each new joystick the system detects
+      next unless controller = controllers[event.which]?
+
+      controller.finalize
+      controllers.delete(event.which)
+      puts "Controller ##{event.which} was disconnected"
+    end
+  when SDL::Event::ControllerAxis
+    # when a controller axis is moved, event.which returns the device instance id, NOT the device index
+    next unless controller = controllers[event.which]?
+    next unless controller.rumble_triggers?
+
+    # in this example, if you have a controller with rumble triggers, like an XBox one controller, pressing those
+    # will rumble the triggers. we will ignore any other axis motions here.
+    next unless trigger_axis.values.includes?(event.axis)
+
+    left = event.axis == trigger_axis[:left] ? (0xffff * 1 // 2) : 0
+    right = event.axis == trigger_axis[:right] ? (0xffff * 1 // 2) : 0
+
+    # rumble the triggers at 50% for left and right for 500ms based on which trigger was pressed
+    controller.rumble_triggers(left: left.to_u16, right: right.to_u16, duration_ms: 250)
+  end
+
+  renderer.draw_color = SDL::Color[255]
+  renderer.clear
+
+  x = (window.width - texture.width) // 2
+  y = (window.height - texture.height) // 2
+  renderer.copy(texture, dstrect: SDL::Rect[x, y, texture.width, texture.height])
+
+  renderer.present
+end
+
+# clean up data
+controllers.values.each(&.finalize)
+[texture, renderer, window].each(&.finalize)

--- a/src/events.cr
+++ b/src/events.cr
@@ -127,7 +127,7 @@ module SDL
         @event.jaxis
       end
 
-      delegate which, x, y, to: _event
+      delegate which, x, y, axis, value, to: _event
     end
 
     struct JoyBall < Event

--- a/src/gamecontroller.cr
+++ b/src/gamecontroller.cr
@@ -1,0 +1,168 @@
+module SDL
+  class GameController
+    alias Axis = LibSDL::GameControllerAxis
+    alias Button = LibSDL::GameControllerButton
+    alias ButtonBind = LibSDL::GameControllerButtonBind
+
+    enum EventState
+      QUERY  = -1
+      IGNORE
+      ENABLE
+    end
+
+    # Check if the given joystick at `index` is supported by the game controller interface.
+    def self.controller?(index : Int)
+      ret = LibSDL.is_game_controller(index)
+      raise Error.new("SDL_IsGameController") unless ret
+      ret
+    end
+
+    # Get the unsafe pointer to the controller associated with an instance id.
+    def self.from_instance_id(joystick_id : LibSDL::JoystickID)
+      ret = LibSDL.game_controller_from_instance_id(joystick_id)
+      raise Error.new("SDL_GameControllerFromInstanceID") unless ret
+      ret
+    end
+
+    # Get the controller's instance id from its index
+    #
+    # This is primarily used when you receive a SDL::Event::Controller* event and need to map
+    # the device's index id to its device instance id
+    #
+    # If you need the device id from an instance, use `GameController#instance_id`.
+    #
+    # Returns the instance id of the selected joystick. If called on an invalid index, this function returns zero.
+    # This can be called before any joysticks are opened. If the index is out of range, this function will return -1.
+    def self.instance_id(index : Int) : LibSDL::JoystickID
+      LibSDL.joystick_get_device_instance_id(index)
+    end
+
+    # Returns the pointer to the controller at `index` or a null pointer.
+    def self.from_index(index : Int)
+      LibSDL.game_controller_from_player_index(index)
+    end
+
+    # Check if a controller has been opened and is currently connected.
+    def self.connected?(gamecontroller : self)
+      !!LibSDL.game_controller_get_attached(gamecontroller)
+    end
+
+    def initialize(@index : Int32)
+      @gamecontroller = LibSDL.game_controller_open(@index)
+      raise Error.new("SDL_GameControllerOpen") unless @gamecontroller
+    end
+
+    def finalize
+      LibSDL.game_controller_close(self)
+    end
+
+    # Get the controller's instance id from its index
+    def instance_id : LibSDL::JoystickID
+      LibSDL.joystick_get_device_instance_id(@index)
+    end
+
+    # Get the current state of an axis control on a game controller.
+    #
+    # The axis indices start at index 0.
+    # The state is a value ranging from -32768 to 32767. Triggers, however, range from 0 to 32767 (they never return a negative value).
+    def axis(axis : Axis) : Int16
+      LibSDL.game_controller_get_axis(self, axis)
+    end
+
+    # Get the SDL joystick layer binding for a controller axis mapping.
+    def axis_bind(axis : Axis) : ButtonBind
+      LibSDL.game_controller_get_bind_for_axis(self, axis)
+    end
+
+    # Query whether a game controller has a given axis.
+    def axis?(axis : Axis)
+      !!LibSDL.game_controller_has_axis(self, axis)
+    end
+
+    # Get the current state of a button on a game controller.
+    #
+    # Returns 1 for pressed state or 0 for not pressed state.
+    def button(button : Button) : UInt8
+      LibSDL.game_controller_get_button(self, button)
+    end
+
+    # Get the SDL joystick layer binding for a controller button mapping.
+    def button_bind(button : Button) : ButtonBind
+      LibSDL.game_controller_get_bind_for_button(self, button)
+    end
+
+    # Query whether a game controller has a given button.
+    def button?(button : Button)
+      !!LibSDL.game_controller_has_button(self, button)
+    end
+
+    # Returns the same value passed to the function, with exception to -1 (QUERY), which will return the current state
+    def event_state(state : EventState)
+      LibSDL.game_controller_event_state(state)
+    end
+
+    # Get the player index of an opened game controller.
+    #
+    # Returns the player index for controller, or -1 if it's not available.
+    # For XInput controllers this returns the XInput user index.
+    def index : Int
+      LibSDL.game_controller_get_player_index(self)
+    end
+
+    # Trigger a rumble effect.
+    # Each call to this function cancels any previous rumble effect, and calling it with 0 intensity stops any rumbling.
+    def rumble(low_freq : UInt16, high_freq : UInt16, duration_ms : UInt32) : Int
+      ret = LibSDL.game_controller_rumble(self, low_freq, high_freq, duration_ms)
+      # Workaround: using has_rumble? since the controller can sometimes
+      # return -1 the first time it's checked for rumble support within SDL
+      # (based on local testing on Windows with XBox one controller)
+      raise Error.new("SDL_GameControllerHasRumble") unless rumble?
+      ret
+    end
+
+    # Start a rumble effect in the game controller's triggers.
+    #
+    # Returns 0, or -1 if trigger rumble isn't supported on this controller
+    # Each call to this function cancels any previous trigger rumble effect, and calling it with 0 intensity stops any rumbling.
+    # Note that this is rumbling of the _triggers_ and not the game controller as a whole.
+    # This is currently only supported on Xbox One controllers.
+    # If you want the (more common) whole-controller rumble, use `rumble` instead.
+    def rumble_triggers(left : UInt16, right : UInt16, duration_ms : UInt32) : Int
+      LibSDL.game_controller_rumble_triggers(self, left, right, duration_ms)
+    end
+
+    # Check if the game controller supports rumble functionality.
+    def rumble?
+      !!LibSDL.game_controller_has_rumble(self)
+    end
+
+    # Query whether a game controller has rumble support on triggers.
+    def rumble_triggers?
+      !!LibSDL.game_controller_has_rumble_triggers(self)
+    end
+
+    # Update a game controller's LED color.
+    #
+    # Returns 0, or -1 if this controller does not have a modifiable LED
+    def led_color=(rgb : Tuple(UInt8, UInt8, UInt8)) : Int
+      LibSDL.game_controller_set_led(self, *rgb)
+    end
+
+    # Query whether a game controller has an LED.
+    def led?
+      !!LibSDL.game_controller_has_led(self)
+    end
+
+    # Manually pump game controller updates if not using the loop.
+    #
+    # This function is called automatically by the event loop if events are enabled.
+    # Under such circumstances, it will not be necessary to call this function.
+    def update
+      LibSDL.game_controller_update
+    end
+
+    def to_unsafe
+      @gamecontroller
+    end
+  end
+end

--- a/src/lib_sdl/gamecontroller.cr
+++ b/src/lib_sdl/gamecontroller.cr
@@ -29,6 +29,12 @@ lib LibSDL
     BUTTON_DPAD_DOWN
     BUTTON_DPAD_LEFT
     BUTTON_DPAD_RIGHT
+    BUTTON_MISC1
+    BUTTON_PADDLE1
+    BUTTON_PADDLE2
+    BUTTON_PADDLE3
+    BUTTON_PADDLE4
+    BUTTON_TOUCHPAD
     BUTTON_MAX
   end
 
@@ -61,25 +67,36 @@ lib LibSDL
   fun game_controller_add_mapping = SDL_GameControllerAddMapping(mappingString : Char*) : Int
   fun game_controller_mapping_for_guid = SDL_GameControllerMappingForGUID(guid : JoystickGUID) : Char*
   fun game_controller_mapping = SDL_GameControllerMapping(gamecontroller : GameController*) : Char*
+  fun game_controller_get_player_index = SDL_GameControllerGetPlayerIndex(gamecontroller : GameController*) : Int
+  fun game_controller_from_player_index = SDL_GameControllerFromPlayerIndex(index : Int) : GameController*
+  fun game_controller_from_instance_id = SDL_GameControllerFromInstanceID(joystick_id : LibSDL::JoystickID) : GameController*
   fun is_game_controller = SDL_IsGameController(joystick_index : Int) : Bool
+  fun game_controller_rumble = SDL_GameControllerRumble(gamecontroller : GameController*, low_freq : UInt16, high_freq : UInt16, duration_ms : UInt32) : Int
+  fun game_controller_rumble_triggers = SDL_GameControllerRumbleTriggers(gamecontroller : GameController*, left : UInt16, right : UInt16, duration_ms : UInt32) : Int
+  fun game_controller_has_rumble = SDL_GameControllerHasRumble(gamecontroller : GameController*) : Bool
+  fun game_controller_has_rumble_triggers = SDL_GameControllerHasRumbleTriggers(gamecontroller : GameController*) : Bool
   fun game_controller_name_for_index = SDL_GameControllerNameForIndex(joystick_index : Int)
   fun game_controller_open = SDL_GameControllerOpen(joystick_index : Int) : GameController*
   fun game_controller_name = SDL_GameControllerName(gamecontroller : GameController*) : Char*
   fun game_controller_get_attached = SDL_GameControllerGetAttached(gamecontroller : GameController*) : Bool
   fun game_controller_get_joystick = SDL_GameControllerGetJoystick(gamecontroller : GameController*) : Joystick*
-  fun game_controller_event_state = SDL_GameControllerEventState(gamecontroller : GameController*) : Int
-  fun game_controller_event_state = SDL_GameControllerEventState(gamecontroller : GameController*) : Int
-  fun game_controller_update = SDL_GameControllerUpdate()
+  fun game_controller_event_state = SDL_GameControllerEventState(state : Int) : Int
+  fun game_controller_update = SDL_GameControllerUpdate
 
+  fun game_controller_has_axis = SDL_GameControllerHasAxis(gamecontroller : GameController*, axis : GameControllerAxis) : Bool
   fun game_controller_get_axis_from_string = SDL_GameControllerGetAxisFromString(pchString : Char*) : GameControllerAxis
   fun game_controller_get_string_for_axis = SDL_GameControllerGetStringForAxis(axis : GameControllerAxis) : Char*
   fun game_controller_get_bind_for_axis = SDL_GameControllerGetBindForAxis(gamecontroller : GameController*, axis : GameControllerAxis) : GameControllerButtonBind
   fun game_controller_get_axis = SDL_GameControllerGetAxis(gamecontroller : GameController*, axis : GameControllerAxis) : Int16
 
+  fun game_controller_has_button = SDL_GameControllerHasButton(gamecontroller : GameController*, button : GameControllerButton) : Bool
   fun game_controller_get_button_from_string = SDL_GameControllerGetButtonFromString(pchString : Char*) : GameControllerButton
   fun game_controller_get_string_for_button = SDL_GameControllerGetStringForButton(button : GameControllerButton) : Char*
   fun game_controller_get_bind_for_button = SDL_GameControllerGetBindForButton(gamecontroller : GameController*, button : GameControllerButton) : GameControllerButtonBind
   fun game_controller_get_button = SDL_GameControllerGetButton(gamecontroller : GameController*, button : GameControllerButton) : UInt8
+
+  fun game_controller_set_led = SDL_GameControllerSetLED(gamecontroller : GameController*, red : UInt8, green : UInt8, blue : UInt8) : Int
+  fun game_controller_has_led = SDL_GameControllerHasLED(gamecontroller : GameController*) : Bool
 
   fun game_controller_close = SDL_GameControllerClose(gamecontroller : GameController*)
 end

--- a/src/lib_sdl/joystick.cr
+++ b/src/lib_sdl/joystick.cr
@@ -25,6 +25,7 @@ lib LibSDL
   fun joystick_get_guid_string = SDL_JoystickGetGUIDString(guid : JoystickGUID, pszGUID : Char*, cbGUID : Int)
   fun joystick_get_guid_rom_string = SDL_JoystickGetGUIDFromString(pchGuid : Char*)
   fun joystick_get_attached = SDL_JoystickGetAttached(joystick : Joystick*) : Bool
+  fun joystick_get_device_instance_id = SDL_JoystickGetDeviceInstanceID(device_index : Int) : JoystickID
   fun joystick_instance_id = SDL_JoystickInstanceID(joystick : Joystick*) : JoystickID
   fun joystick_num_axes = SDL_JoystickNumAxes(joystick : Joystick*) : Int
   fun joystick_num_balls = SDL_JoystickNumBalls(joystick : Joystick*) : Int

--- a/src/sdl.cr
+++ b/src/sdl.cr
@@ -21,6 +21,7 @@ require "./renderer"
 require "./window"
 require "./screensaver"
 require "./color"
+require "./gamecontroller"
 
 module SDL
   class Error < Exception


### PR DESCRIPTION
Added the `SDL::GameController` wrapper class for the `SDL_GameController*` bindings that made sense to implement. Two samples were also added

https://lazyfoo.net/tutorials/SDL/19_gamepads_and_joysticks/index.php
https://lazyfoo.net/tutorials/SDL/20_force_feedback/index.php